### PR TITLE
Fix patch conflict after upstream implementation

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = glfw-git-minecraft
 	pkgdesc = Free, open source, portable framework for OpenGL application development (git version, patched for Minecraft with Wayland support)
-	pkgver = 3.3.r781.g3eaf1255
+	pkgver = 3.3.r915.g64b4f0f3
 	pkgrel = 1
 	url = https://github.com/KernelFreeze/glfw-minecraft
 	arch = x86_64
@@ -31,10 +31,10 @@ pkgbase = glfw-git-minecraft
 	conflicts = glfw-wayland
 	conflicts = glfw-git
 	source = glfw::git+https://github.com/glfw/glfw
-	source = 0001-Don-t-crash-on-calls-to-focus-or-icon.patch
+	source = 0001-Don-t-crash-on-calls-to-icon.patch
 	source = 0002-Platform-Prefer-Wayland-over-X11.patch
 	sha512sums = SKIP
-	sha512sums = 585d8f06d59ab44edd242a5dded1efcf5f7c0feeef13188534eefe85d324d724c5b90ac444be8365058efa553e437be57eb6d21f28f089f24cdef68c72f29f34
+	sha512sums = 1dab10dd65ca5bead3fa1df8bfa6541b4a52b6d97448484906eb0326cf4868fbeea8250694d10616696b4e7dc135227e7dc12039ab099a234f2f2332185c4c87
 	sha512sums = c8f59dcc5376a6e74d7d072a43f7fa22253052b9e9ae1c99bdab8a779096d2e3a374f11723a57e0ca1f767dbac0fbb3e5cb0439c59096423114c7ab5d54d74af
 
 pkgname = glfw-git-minecraft

--- a/0001-Don-t-crash-on-calls-to-icon.patch
+++ b/0001-Don-t-crash-on-calls-to-icon.patch
@@ -21,16 +21,5 @@ index 7b9e3d0d..0483e54d 100644
  }
  
  void _glfwGetWindowPosWayland(_GLFWwindow* window, int* xpos, int* ypos)
-@@ -2353,8 +2352,7 @@ void _glfwRequestWindowAttentionWayland(_GLFWwindow* window)
- 
- void _glfwFocusWindowWayland(_GLFWwindow* window)
- {
--    _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
--                    "Wayland: The platform does not support setting the input focus");
-+    fprintf(stderr, "Ignoring Error: Wayland: The platform does not support setting the input focus\n");
- }
- 
- void _glfwSetWindowMonitorWayland(_GLFWwindow* window,
--- 
 2.42.0
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@
 
 _pkgbase=glfw
 pkgname=glfw-git-minecraft
-pkgver=3.3.r781.g3eaf1255
+pkgver=3.3.r915.g64b4f0f3
 pkgrel=1
 pkgdesc="Free, open source, portable framework for OpenGL application development (git version, patched for Minecraft with Wayland support)"
 arch=('x86_64' 'armv7h' 'aarch64')
@@ -21,10 +21,10 @@ optdepends=('libgl: for OpenGL support'
             'vulkan-icd-loader: for Vulkan support'
             'vulkan-driver: for Vulkan support')
 source=("$_pkgbase::git+https://github.com/glfw/glfw"
-        "0001-Don-t-crash-on-calls-to-focus-or-icon.patch"
+        "0001-Don-t-crash-on-calls-to-icon.patch"
         "0002-Platform-Prefer-Wayland-over-X11.patch")
 sha512sums=('SKIP'
-            '585d8f06d59ab44edd242a5dded1efcf5f7c0feeef13188534eefe85d324d724c5b90ac444be8365058efa553e437be57eb6d21f28f089f24cdef68c72f29f34'
+            '1dab10dd65ca5bead3fa1df8bfa6541b4a52b6d97448484906eb0326cf4868fbeea8250694d10616696b4e7dc135227e7dc12039ab099a234f2f2332185c4c87'
             'c8f59dcc5376a6e74d7d072a43f7fa22253052b9e9ae1c99bdab8a779096d2e3a374f11723a57e0ca1f767dbac0fbb3e5cb0439c59096423114c7ab5d54d74af')
 
 pkgver() {


### PR DESCRIPTION
This fixes a patch file not being able to be applied due to glfwFocusWindow being implemented for wayland upstream.
https://github.com/glfw/glfw/commit/a360198f8f983d7d85990748c411fb7a82654203